### PR TITLE
[1.21.1] Modification of certain functions to improve Cyclic development

### DIFF
--- a/src/main/java/com/lothrazar/library/packet/PacketPlayerFalldamage.java
+++ b/src/main/java/com/lothrazar/library/packet/PacketPlayerFalldamage.java
@@ -18,8 +18,16 @@ public class PacketPlayerFalldamage extends PacketFlib implements CustomPacketPa
   public static final CustomPacketPayload.Type<PacketPlayerFalldamage> TYPE =
       new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(FutureLibMod.MODID, "fall_damage"));
 
-  public static final StreamCodec<FriendlyByteBuf, PacketPlayerFalldamage> STREAM_CODEC =
-      StreamCodec.unit(new PacketPlayerFalldamage());
+  public static final StreamCodec<FriendlyByteBuf, PacketPlayerFalldamage> STREAM_CODEC = StreamCodec.of(
+      PacketPlayerFalldamage::encode,
+      PacketPlayerFalldamage::decode
+  );
+
+  public static PacketPlayerFalldamage decode(FriendlyByteBuf buf) {
+    return new PacketPlayerFalldamage();
+  }
+
+  public static void encode(FriendlyByteBuf buf, PacketPlayerFalldamage packet) {}
 
   @Override
   public CustomPacketPayload.Type<? extends CustomPacketPayload> type() {

--- a/src/main/java/com/lothrazar/library/render/type/FakeBlockRenderTypes.java
+++ b/src/main/java/com/lothrazar/library/render/type/FakeBlockRenderTypes.java
@@ -38,7 +38,7 @@ public class FakeBlockRenderTypes extends RenderType {
   public final static ResourceLocation BEAM = ResourceLocation.fromNamespaceAndPath(FutureLibMod.MODID, "textures/effect/beam.png");
 
   public static final RenderType LASER_MAIN_BEAM = create(FutureLibMod.MODID + ":mininglasermainbeam",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
+      DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
       RenderType.CompositeState.builder()
           .setTextureState(new TextureStateShard(BEAM, BLUR, MIPMAP))
           .setShaderState(RENDERTYPE_TEXT_SHADER) // was POSITION_COLOR_TEX_SHADER
@@ -54,7 +54,7 @@ public class FakeBlockRenderTypes extends RenderType {
    *
    */
   public static final RenderType FAKE_BLOCK = create(FutureLibMod.MODID + ":fakeblock",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
+      DefaultVertexFormat.BLOCK, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
       RenderType.CompositeState.builder()
           .setShaderState(RENDERTYPE_SOLID_SHADER) //1.17 was -   BLOCK_SHADER
           .setLayeringState(POLYGON_OFFSET_LAYERING) // VIEW_OFFSET_Z_LAYERING)
@@ -69,7 +69,7 @@ public class FakeBlockRenderTypes extends RenderType {
    * used by EventRender -> RenderWorldLastEvent by most held items that pick locations, such as cyclic:location_data
    */
   public static final RenderType TRANSPARENT_COLOUR = create(FutureLibMod.MODID + ":transparentcolour",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
+      DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
       RenderType.CompositeState.builder()
           .setShaderState(RENDERTYPE_LINES_SHADER)
           .setLayeringState(VIEW_OFFSET_Z_LAYERING)
@@ -87,7 +87,7 @@ public class FakeBlockRenderTypes extends RenderType {
    *
    */
   public static final RenderType SOLID_COLOUR = create(FutureLibMod.MODID + ":solidcolour",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
+      DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, BUFFERSIZE, CRUMBLING, SORT,
       RenderType.CompositeState.builder()
           .setShaderState(RENDERTYPE_LINES_SHADER)
           .setLayeringState(VIEW_OFFSET_Z_LAYERING)
@@ -103,7 +103,7 @@ public class FakeBlockRenderTypes extends RenderType {
    * Used by cyclic:prospector
    */
   public static final RenderType TOMB_LINES = create(FutureLibMod.MODID + ":tomb_lines",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.LINES, BUFFERSIZE, CRUMBLING, SORT,
+      DefaultVertexFormat.POSITION_COLOR_NORMAL, VertexFormat.Mode.LINES, BUFFERSIZE, CRUMBLING, SORT,
       RenderType.CompositeState.builder()
           .setShaderState(RENDERTYPE_LINES_SHADER)
           .setLineState(new LineStateShard(OptionalDouble.of(2.5D)))

--- a/src/main/java/com/lothrazar/library/render/type/LaserRenderType.java
+++ b/src/main/java/com/lothrazar/library/render/type/LaserRenderType.java
@@ -28,7 +28,7 @@ public class LaserRenderType extends RenderType {
   private final static ResourceLocation RL_BEAM = ResourceLocation.fromNamespaceAndPath(FutureLibMod.MODID, "textures/effect/beam.png");
   private final static ResourceLocation RL_GLOW = ResourceLocation.fromNamespaceAndPath(FutureLibMod.MODID, "textures/effect/glow.png");
   public static final RenderType LASER_MAIN_BEAM = create("MAIN_",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+      DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
       RenderType.CompositeState.builder().setTextureState(new TextureStateShard(RL_BEAM, false, false))
           .setShaderState(RENDERTYPE_TEXT_SHADER) // was POSITION_COLOR_TEX_SHADER
           .setLayeringState(VIEW_OFFSET_Z_LAYERING)
@@ -39,7 +39,7 @@ public class LaserRenderType extends RenderType {
           .setWriteMaskState(COLOR_WRITE)
           .createCompositeState(false));
   public static final RenderType LASER_MAIN_ADDITIVE = create("MiningLaserAdditiveBeam",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+      DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
       RenderType.CompositeState.builder().setTextureState(new TextureStateShard(RL_GLOW, false, false))
           .setShaderState(RENDERTYPE_TEXT_SHADER) // was POSITION_COLOR_TEX_SHADER
           .setLayeringState(VIEW_OFFSET_Z_LAYERING)
@@ -50,7 +50,7 @@ public class LaserRenderType extends RenderType {
           .setWriteMaskState(COLOR_WRITE)
           .createCompositeState(false));
   public static final RenderType LASER_MAIN_CORE = create("MiningLaserCoreBeam",
-      DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP, VertexFormat.Mode.QUADS, 256, false, false,
+      DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 256, false, false,
       RenderType.CompositeState.builder().setTextureState(new TextureStateShard(RL_LASER, false, false))
           .setShaderState(RENDERTYPE_TEXT_SHADER)// was POSITION_COLOR_TEX_SHADER
           .setLayeringState(VIEW_OFFSET_Z_LAYERING)

--- a/src/main/java/com/lothrazar/library/util/RenderBlockUtils.java
+++ b/src/main/java/com/lothrazar/library/util/RenderBlockUtils.java
@@ -16,6 +16,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.player.LocalPlayer;
 
+import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
@@ -30,6 +31,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
@@ -99,7 +101,7 @@ public class RenderBlockUtils {
         g = 1f;
         b = 1f;
       }
-      //      addVertexData 
+      //      addVertexData
       boolean readExistingColor = false;
       builder.putBulkData(matrixEntry, bakedquad, r, g, b, alpha, combinedLights, combinedOverlay, readExistingColor);
     }
@@ -174,7 +176,7 @@ public class RenderBlockUtils {
 
   /**
    * Call from TESR perspective
-   * 
+   *
    * @param level
    */
   public static void renderAsBlock(Level level, final BlockPos centerPos, final List<BlockPos> shape, PoseStack matrix, ItemStack stack, float alpha, float scale) {
@@ -184,9 +186,9 @@ public class RenderBlockUtils {
 
   /**
    * Render this BLOCK right here in the world, start with alpha and scale near 1. Call from TESR perspective
-   * 
+   *
    * used by cyclic:light_camo
-   * 
+   *
    */
   public static void renderAsBlock(Level world, final BlockPos centerPos, final List<BlockPos> shape, PoseStack matrix, BlockState renderBlockState, float alpha, float scale) {
 
@@ -222,7 +224,7 @@ public class RenderBlockUtils {
         for (Direction direction : Direction.values()) {
           RenderBlockUtils.renderModelBrightnessColorQuads(matrix.last(), builder, red, green, blue, alpha,
               ibakedmodel.getQuads(renderBlockState, direction, world.random,
-                  ibakedmodel.getModelData(world, centerPos, renderBlockState, null), FakeBlockRenderTypes.FAKE_BLOCK), // EmptyModelData.INSTANCE 
+                  ibakedmodel.getModelData(world, centerPos, renderBlockState, null), FakeBlockRenderTypes.FAKE_BLOCK), // EmptyModelData.INSTANCE
               combinedLights, combinedOverlay);
         }
       }
@@ -243,7 +245,7 @@ public class RenderBlockUtils {
 
   /**
    * Used by TESRs
-   * 
+   *
    * View can be tile entity position, or player pos depending on context mc.gameRenderer.getMainCamera().getPosition();
    */
   public static void renderOutline(BlockPos view, List<BlockPos> coords, PoseStack matrix, float scale, Color color) {
@@ -273,7 +275,7 @@ public class RenderBlockUtils {
 
   /**
    * Create your own PoseStack and view perspective and use the method that does not depend on forge events
-   * 
+   *
    * @param evt
    * @param coords
    * @param alpha
@@ -327,6 +329,8 @@ public class RenderBlockUtils {
   public static void createBox(MultiBufferSource.BufferSource bufferSource, Vec3 cameraPosition, PoseStack poseStack, float x, float y, float z, float offset) {
     //rainbow magic
     float[] color = getRandomColour();
+    final float red = color[0], green = color[1], blue = color[2], alpha = 1.0F;
+
     // get a closer pos if too far
     Vec3 vec = new Vec3(x, y, z).subtract(cameraPosition);
     if (vec.distanceTo(Vec3.ZERO) > 200d) { // could be 300
@@ -335,36 +339,28 @@ public class RenderBlockUtils {
       y += vec.y;
       z += vec.z;
     }
+
+    poseStack.pushPose();
+    poseStack.translate(
+            x - cameraPosition.x,
+            y - cameraPosition.y,
+            z - cameraPosition.z
+    );
+
     RenderSystem.disableDepthTest();
-    VertexConsumer vertexConsumer = bufferSource.getBuffer(FakeBlockRenderTypes.TOMB_LINES);
-    poseStack.translate(-cameraPosition.x, -cameraPosition.y, -cameraPosition.z);
-    Matrix4f pose = poseStack.last().pose();
-    vertexConsumer.addVertex(pose, x, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y + offset, z).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x + offset, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y, z + offset).setColor(color[0], color[1], color[2], 1.0F);
-    vertexConsumer.addVertex(pose, x, y + offset, z + offset).setColor(color[0], color[1], color[2], 1.0F);
+    VertexConsumer lines = bufferSource.getBuffer(FakeBlockRenderTypes.TOMB_LINES);
+
+    // Renders the outline of a single block
+    LevelRenderer.renderLineBox(
+            poseStack,
+            lines,
+            new AABB(0, 0, 0, 1, 1, 1), // Local AABB (origin = block corner)
+            red, green, blue, alpha
+    );
+
     bufferSource.endBatch(FakeBlockRenderTypes.TOMB_LINES);
     RenderSystem.enableDepthTest();
+    poseStack.popPose();
   }
 
   public static float[] getRandomColour() {

--- a/src/main/java/com/lothrazar/library/util/TagDataUtil.java
+++ b/src/main/java/com/lothrazar/library/util/TagDataUtil.java
@@ -11,6 +11,8 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ResolvableProfile;
 
+import java.util.function.Consumer;
+
 public class TagDataUtil {
 
   public static final String SKULLOWNER = "SkullOwner";
@@ -62,11 +64,23 @@ public class TagDataUtil {
   }
 
   public static void setItemStackNBTVal(ItemStack item, String prop, int value) {
+    setItemStackNBTVal(item, tag -> tag.putInt(prop, value));
+  }
+
+  public static void setItemStackNBTVal(ItemStack item, String prop, String value) {
+    setItemStackNBTVal(item, tag -> tag.putString(prop, value));
+  }
+
+  public static void setItemStackNBTVal(ItemStack item, String prop, double value) {
+    setItemStackNBTVal(item, tag -> tag.putDouble(prop, value));
+  }
+
+  private static void setItemStackNBTVal(ItemStack item, Consumer<CompoundTag> writer) {
     if (item.isEmpty()) {
       return;
     }
     CompoundTag tag = item.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-    tag.putInt(prop, value);
+    writer.accept(tag);
     item.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
   }
 

--- a/src/main/java/com/lothrazar/library/util/TagDataUtil.java
+++ b/src/main/java/com/lothrazar/library/util/TagDataUtil.java
@@ -75,6 +75,10 @@ public class TagDataUtil {
     setItemStackNBTVal(item, tag -> tag.putDouble(prop, value));
   }
 
+  public static void setItemStackNBTVal(ItemStack item, String prop, long value) {
+    setItemStackNBTVal(item, tag -> tag.putLong(prop, value));
+  }
+
   private static void setItemStackNBTVal(ItemStack item, Consumer<CompoundTag> writer) {
     if (item.isEmpty()) {
       return;


### PR DESCRIPTION
Additions:
- New Consumer-based function for setItemStackNBTVal in TagDataUtil; now supports int, String and double values to be added to the tags

Modifications:
- Default vertex format in FakeBlockRenderTypes, to prevent the game from crashing when calling these methods; the implementation does not take into account a texture or lighting map, so the vertex format should reflect it.
- Use of LevelRenderer instead of manually adding vertexes to a Consumer; allows for a better anti-aliasing on the block outlines drawn

If you have any constructive comments, let me know! Thank you!