### PR TITLE
Fix MissingPaletteEntryException crash when cyclic enchantments are missing

### DIFF
--- a/src/main/java/com/lothrazar/library/util/EnchantUtil.java
+++ b/src/main/java/com/lothrazar/library/util/EnchantUtil.java
@@ -2,6 +2,7 @@ package com.lothrazar.library.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
@@ -64,8 +65,21 @@ public class EnchantUtil {
     }
     return false;
   }
+
   public static Holder<Enchantment> holder(ResourceKey<Enchantment> key, Level level) {
-    return level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(key);
+    try {
+      var registry = level.registryAccess().lookup(Registries.ENCHANTMENT);
+      if (registry.isEmpty()) {
+        return null;
+      }
+      var holder = registry.get().get(key);
+      if (holder.isEmpty()) {
+        return null;
+      }
+      return holder.get();
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   public static Holder<Enchantment> holder(ResourceKey<Enchantment> key, LivingEntity entity) {
@@ -74,18 +88,25 @@ public class EnchantUtil {
 
   public static int getCurrentLevelTool(Holder<Enchantment> enchantment, ItemStack stack) {
     if (stack.isEmpty() || stack.getItem() == Items.ENCHANTED_BOOK) return -1;
+    if (enchantment == null) return -1;
     return EnchantmentHelper.getTagEnchantmentLevel(enchantment, stack);
   }
+
   public static int getCurrentArmorLevel(ResourceKey<Enchantment> key, LivingEntity entity) {
-    return getCurrentArmorLevel(holder(key, entity), entity);
+    Holder<Enchantment> h = holder(key, entity);
+    if (h == null) return 0;
+    return getCurrentArmorLevel(h, entity);
   }
+
   public static int getCurrentArmorLevelSlot(Holder<Enchantment> enchantment, LivingEntity entity, EquipmentSlot type) {
+    if (enchantment == null) return 0;
     ItemStack armor = entity.getItemBySlot(type);
     if (armor.isEmpty()) return 0;
     return EnchantmentHelper.getTagEnchantmentLevel(enchantment, armor);
   }
 
   public static int getCurrentArmorLevel(Holder<Enchantment> enchantment, LivingEntity entity) {
+    if (enchantment == null) return 0;
     EquipmentSlot[] armors = { EquipmentSlot.CHEST, EquipmentSlot.FEET, EquipmentSlot.HEAD, EquipmentSlot.LEGS };
     int level = 0;
     for (EquipmentSlot slot : armors) {
@@ -96,11 +117,12 @@ public class EnchantUtil {
   }
 
   public static int getLevelAll(Holder<Enchantment> enchantment, LivingEntity entity) {
+    if (enchantment == null) return 0;
     return Math.max(getCurrentArmorLevel(enchantment, entity), getCurrentLevelTool(enchantment, entity));
   }
 
   public static ItemStack getFirstArmorStackWithEnchant(Holder<Enchantment> enchantment, LivingEntity entity) {
-    if (entity == null) return ItemStack.EMPTY;
+    if (entity == null || enchantment == null) return ItemStack.EMPTY;
     for (ItemStack armor : entity.getArmorSlots()) {
       if (!armor.isEmpty() && EnchantmentHelper.getTagEnchantmentLevel(enchantment, armor) > 0) {
         return armor;
@@ -110,7 +132,7 @@ public class EnchantUtil {
   }
 
   public static int getCurrentLevelTool(Holder<Enchantment> enchantment, LivingEntity entity) {
-    if (entity == null) return -1;
+    if (entity == null || enchantment == null) return -1;
     ItemStack main = entity.getMainHandItem();
     ItemStack off = entity.getOffhandItem();
     return Math.max(getCurrentLevelTool(enchantment, main), getCurrentLevelTool(enchantment, off));


### PR DESCRIPTION
Fix for crash when connecting to servers that don't have Cyclic enchantments registered.

The EnchantUtil.holder() method used lookupOrThrow() and getOrThrow(), which threw
IllegalStateException when an enchantment was missing. This caused the game to crash
with "Missing element ResourceKey[minecraft:enchantment / cyclic:xxx]".

Changed to use lookup() and get() with null checks, returning null when the enchantment
is not found. All methods that use holder() now check for null before proceeding.

This prevents crashes and allows the game to continue running even when Cyclic
enchantments are not available on the server.